### PR TITLE
feat: alpine-based image with CoreDNS + ExaBGP

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,29 @@
+---
+name: Image Build and Push
+on:
+  push: 
+    branches: [main]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ghcr.io/routedbits/container-anycast-dns:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+---
+name: Release Build and Publish
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get release version
+        id: get_version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ghcr.io/routedbits/container-anycast-dns:${{ env.RELEASE_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.19.1 as build
+
+# Obtain CoreDNS binary
+WORKDIR /tmp
+ADD https://github.com/coredns/coredns/releases/download/v1.11.1/coredns_1.11.1_linux_amd64.tgz ./coredns.tgz
+RUN tar xzvf coredns.tgz
+
+FROM alpine:3.19.1
+
+# CoreDNS
+COPY --chown=root:root --from=build /tmp/coredns /usr/bin/
+RUN mkdir -p /etc/coredns
+
+# ExaBGP
+RUN apk --no-cache add python3 py3-pip bind-tools \
+    && python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install exabgp \ 
+    && mkdir -p /etc/exabgp
+
+ENV PATH /opt/venv/bin:$PATH
+
+COPY entrypoint.sh /
+
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # container-anycast-dns
+
+Containerized ExaBGP + CoreDNS to act as an Anycast DNS server
+
+# Configuration
+
+The image expects to be provided valid configuration files at the following locations
+
+* `/etc/coredns/Corefile`
+* `/etc/exabgp/exabgp.conf`
+
+NOTE: You will need to launch the container with `NET_ADMIN` capability if you wish for it to add/remove IPs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/ash
+
+# Run CoreDNS
+if [ -f /etc/coredns/Corefile ]; then
+    /usr/bin/coredns -conf /etc/coredns/Corefile &
+fi
+
+# Run ExaBGP
+if [ -f /etc/exabgp/exabgp.conf ]; then
+    # Create pipes
+    if [ ! -p /run/exabgp.in ]; then mkfifo /run/exabgp.in; chmod 600 /run/exabgp.in; fi
+    if [ ! -p /run/exabgp.out ]; then mkfifo /run/exabgp.out; chmod 600 /run/exabgp.out; fi
+
+    # Create env file
+    if [ ! -f /etc/exabgp/exabgp.env ]; then
+      exabgp --fi > /etc/exabgp/exabgp.env
+      # bind to all interfaces
+      sed -i "s/^bind = .*/bind = '0.0.0.0'/" /etc/exabgp/exabgp.env 
+      # run as root (otherwise ip add commands wont work)
+      sed -i "s/^user = 'nobody'/user = 'root'/" /etc/exabgp/exabgp.env 
+    fi
+
+    # run 
+    /opt/venv/bin/exabgp /etc/exabgp/exabgp.conf &
+fi
+
+wait -n
+
+echo $?


### PR DESCRIPTION
Alpine-based image that runs CoreDNS + ExaBGP. It expects a Corefile + exabgp.conf to be provided or the container will die

```
-> podman images
REPOSITORY                                TAG         IMAGE ID      CREATED         SIZE
ghcr.io/routedbits/container-anycast-dns  latest      75f1869a5e3e  12 seconds ago  176 MB
```